### PR TITLE
Basic usage of torch-tensorrt python api

### DIFF
--- a/04-torch-tensorrt-python-api-basic-usage/README.md
+++ b/04-torch-tensorrt-python-api-basic-usage/README.md
@@ -1,0 +1,5 @@
+# 04-torch-tensorrt-python-api-basic-usage
+- Torch-TensorRT is now an official part of the PyTorch ecosystem and now available on PyTorch GitHub and Documentation. - [link](https://github.com/pytorch/TensorRT)
+
+## Reference
+- [Pytorch official documentation about torch-tensorrt](https://pytorch.org/TensorRT/tutorials/installation.html)

--- a/04-torch-tensorrt-python-api-basic-usage/README.md
+++ b/04-torch-tensorrt-python-api-basic-usage/README.md
@@ -1,6 +1,16 @@
 # 04-torch-tensorrt-python-api-basic-usage
 - Torch-TensorRT is now an official part of the PyTorch ecosystem and now available on PyTorch GitHub and Documentation. - [link](https://github.com/pytorch/TensorRT)
 
+# Description
+## Core Concepts
+> Ahead of Time (AOT) compiling for PyTorch JIT and FX
+- Torch-TensorRT is a **compiler** for PyTorch/TorchScript/FX, targeting NVIDIA GPUs via NVIDIA's TensorRT Deep Learning Optimizer and Runtime. 
+    - Ahead-of-Time (AOT) compiler. (Not PyTorch's Just-In-Time (JIT) compiler.)
+- Ahead-of-Time (AOT) compiler vs Just-In-Time (JIT) compiler
+    - Ahead-of-Time (AOT) compiler : Explicit compile before excute program.
+    - Just-In-Time (JIT) compiler : Compile when program was excuted time. (Dynamic compile)
+- Torch-TensorRT operates as a PyTorch extention and compiles modules that **integrate into the JIT runtime seamlessly.**
+
 ## Environment
 - Ubuntu 20.04
 - NGC-Pytorch container (ver 22.07)

--- a/04-torch-tensorrt-python-api-basic-usage/README.md
+++ b/04-torch-tensorrt-python-api-basic-usage/README.md
@@ -1,5 +1,9 @@
 # 04-torch-tensorrt-python-api-basic-usage
 - Torch-TensorRT is now an official part of the PyTorch ecosystem and now available on PyTorch GitHub and Documentation. - [link](https://github.com/pytorch/TensorRT)
 
+## Environment
+- Ubuntu 20.04
+- NGC-Pytorch container (ver 22.07)
+
 ## Reference
 - [Pytorch official documentation about torch-tensorrt](https://pytorch.org/TensorRT/tutorials/installation.html)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # TODO
-1. TensorRT Cifar10 PTQ example
-2. TensorRT Cifar10 QAT example
-3. Torch-TensorRT basic usage example
-4. [Torch-TensorRT](https://github.com/NVIDIA/Torch-TensorRT) vs Torch -> onnx -> TensorRT benchmark
-
+1. Simple tensorrt evaluation code.
+2. [Torch-TensorRT](https://github.com/NVIDIA/Torch-TensorRT) vs Torch -> onnx -> TensorRT benchmark
+3. TensorRT Cifar10 PTQ example 
+4. TensorRT Cifar10 QAT example
 
 # Tensorrt toycode
 - [TensorRT Tips](./00-tensorrt-tips/)


### PR DESCRIPTION
# Description
- Torch-TensorRT is now an official part of the PyTorch ecosystem and now available on PyTorch GitHub and Documentation.
- Basic usage of torch-tensorrt python api